### PR TITLE
Bug fix:  The test for the insecure api would crash if it got a 404/N…

### DIFF
--- a/gem/lib/kube_auto_analyzer/vuln_checks/api_server.rb
+++ b/gem/lib/kube_auto_analyzer/vuln_checks/api_server.rb
@@ -18,6 +18,8 @@ module KubeAutoAnalyzer
           pods_resp = RestClient::Request.execute(:url => "http://#{nod}:8080/api",:method => :get)
         rescue RestClient::Forbidden
           pods_resp = "Not Vulnerable - Request Forbidden"
+        rescue RestClient::NotFound
+          pods_resp = "Not Vulnerable - Request Not Found"
         end
         @results[target]['vulns']['insecure_api_external'][nod] = pods_resp
       else


### PR DESCRIPTION
…otFound instead of the expected 403/Forbidden.  The test before that to see if port 8080 is "open" is insufficient to prevent this crash from happening.